### PR TITLE
Add ios fullscreen helper

### DIFF
--- a/sketch/index.html
+++ b/sketch/index.html
@@ -3,6 +3,8 @@
 <head>
   <title>my sketch</title>
 
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="iosfullscreen.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.js"></script>
   <script src="sketch.js"></script>
 

--- a/sketch/iosfullscreen.js
+++ b/sketch/iosfullscreen.js
@@ -1,0 +1,54 @@
+// MIT License
+//
+// Copyright (c) 2024 Tetsunori Nakayama
+
+let gCanvasStream = undefined;
+let gVideoElement = undefined;
+
+const CANVAS_VIDEO_ID = 'canvasVideo';
+
+// Create Video element from p5.js canvas
+// Actually, we make the tag below under body element.
+//   <video id="canvasVideo" width='100%' controls></video>
+const createCanvasVideoElement = () => {
+  if (gVideoElement) {
+    return;
+  }
+  const vElm = document.createElement('video');
+  vElm.id = CANVAS_VIDEO_ID;
+  vElm.setAttribute('width', '100%');
+  vElm.setAttribute('controls', '');
+
+  // Insert video tag as first child
+  document.body.insertBefore(vElm, document.body.firstChild);
+  gVideoElement = vElm;
+};
+
+function iOSfullscreen() {
+  // Judge whether the device is iOS or not.
+  const ua = window.navigator.userAgent.toLowerCase();
+  if (ua.indexOf('iphone') !== -1 || ua.indexOf('ipad') !== -1) {
+    // iOS user!
+
+    createCanvasVideoElement();
+
+    if (gCanvasStream) {
+      // Initialize stream if canvasStream already exists
+      const tracks = gCanvasStream?.getTracks();
+      tracks.forEach((track) => {
+        track.stop();
+      });
+      gCanvasStream = undefined;
+    }
+
+    const canvasElm = document.querySelector('canvas');
+
+    // Hide canvas
+    canvasElm.setAttribute('visibility', 'hidden');
+
+    // Start capuring stream and set it into video source.
+    gCanvasStream = canvasElm.captureStream();
+    const canvasVideo = document.getElementById(CANVAS_VIDEO_ID);
+    canvasVideo.srcObject = gCanvasStream;
+  }
+}

--- a/sketch/sketch.js
+++ b/sketch/sketch.js
@@ -17,6 +17,7 @@ function setup() {
   stroke(255, 50, 0);
 
   background(0);
+  iOSfullscreen();
 }
 
 function draw() {
@@ -69,7 +70,7 @@ function draw() {
 }
 
 function mouseClicked() {
-  if (isFullScreen) {
+  if (!isFullScreen) {
     fullscreen(true);
   } else {
     fullscreen(false);


### PR DESCRIPTION
Hi @reona396 

Thanks for using p5.simpleAR lib!🥰
I have just came up with an idea for iOS/iPad (pseudo)full screen feature by using WebRTC capture stream function(actually it generating tentative movie from p5js canvas dynamically).
- There is no side effect except for iOS/iPad devices
- It cannot be used in interactive sketches though..😅

This is just a light sharing thoughts so that you can feel free to reject it~.

### How to use
After starting your sketch, please press 'play movie' button and also press 'full screen' mark on top-left of streaming movie.